### PR TITLE
HS-403: send iv as query param

### DIFF
--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -42,7 +42,6 @@ export const spec = {
         page: loc.host + loc.pathname + loc.search + loc.hash
       }
     };
-    if (iv) sovrnBidReq.iv = iv;
 
     if (bidderRequest && bidderRequest.gdprConsent) {
       sovrnBidReq.regs = {
@@ -55,9 +54,13 @@ export const spec = {
         }};
     }
 
+    let url = `//ap.lijit.com/rtb/bid?` +
+        `src=${REPO_AND_VERSION}`;
+    if (iv) url += `&iv=${iv}`;
+
     return {
       method: 'POST',
-      url: `//ap.lijit.com/rtb/bid?src=${REPO_AND_VERSION}`,
+      url: url,
       data: JSON.stringify(sovrnBidReq),
       options: {contentType: 'text/plain'}
     };

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -81,7 +81,7 @@ describe('sovrnBidAdapter', function() {
       }];
       const request = spec.buildRequests(ivBidRequests);
 
-      expect(request.data).to.contain('"iv":"vet"')
+      expect(request.url).to.contain('iv=vet')
     });
 
     it('sends gdpr info if exists', () => {


### PR DESCRIPTION
`iv` needs to be sent as a query param for BB to log it, not in the post body