### PR TITLE
Ex 2427 - Add Configurable TTL for Bid Response

### DIFF
--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -143,7 +143,7 @@ export const spec = {
             netRevenue: true,
             mediaType: BANNER,
             ad: decodeURIComponent(`${sovrnBid.adm}<img src="${sovrnBid.nurl}">`),
-            ttl: 60
+            ttl: sovrnBid.ttl || 90
           });
         });
       }

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -331,16 +331,16 @@ describe('sovrnBidAdapter', function() {
         'currency': 'USD',
         'netRevenue': true,
         'mediaType': 'banner',
-        'ad': decodeURIComponent(`<!-- Creative --><img src=<!-- NURL -->>`),
-        'ttl': 60000
+        'ad': decodeURIComponent(`<!-- Creative --><img src="<!-- NURL -->">`),
+        'ttl': 90
       }];
 
       let result = spec.interpretResponse(response);
-      expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
+      expect(result[0]).to.deep.equal(expectedResponse[0]);
     });
 
     it('should get correct bid response when dealId is passed', function () {
-      response.body.dealid = 'baking';
+      response.body.seatbid[0].bid[0].dealid = 'baking';
 
       let expectedResponse = [{
         'requestId': '263c448586f5a1',
@@ -352,12 +352,33 @@ describe('sovrnBidAdapter', function() {
         'currency': 'USD',
         'netRevenue': true,
         'mediaType': 'banner',
-        'ad': decodeURIComponent(`<!-- Creative --><img src=<!-- NURL -->>`),
-        'ttl': 60000
+        'ad': decodeURIComponent(`<!-- Creative --><img src="<!-- NURL -->">`),
+        'ttl': 90
       }];
 
       let result = spec.interpretResponse(response);
-      expect(Object.keys(result[0])).to.deep.equal(Object.keys(expectedResponse[0]));
+      expect(result[0]).to.deep.equal(expectedResponse[0]);
+    });
+
+    it('should get correct bid response when ttl is set', function () {
+      response.body.seatbid[0].bid[0].ttl = 480;
+
+      let expectedResponse = [{
+        'requestId': '263c448586f5a1',
+        'cpm': 0.45882675,
+        'width': 728,
+        'height': 90,
+        'creativeId': 'creativelycreatedcreativecreative',
+        'dealId': null,
+        'currency': 'USD',
+        'netRevenue': true,
+        'mediaType': 'banner',
+        'ad': decodeURIComponent(`<!-- Creative --><img src="<!-- NURL -->">`),
+        'ttl': 480
+      }];
+
+      let result = spec.interpretResponse(response);
+      expect(result[0]).to.deep.equal(expectedResponse[0]);
     });
 
     it('handles empty bid response', function () {


### PR DESCRIPTION
So this makes it so that BB can send a TTL for bid responses which will enable bid caching in the future.

I also noticed that the bid response unit tests did not test anything. which was bad and is now fixed.