### PR TITLE
EX 5154- beacon calls point to ce.lijit.com

### DIFF
--- a/modules/sovrnBidAdapter.js
+++ b/modules/sovrnBidAdapter.js
@@ -271,7 +271,7 @@ export const spec = {
             params.push(['informer', iidArr[0]]);
             tracks.push({
               type: 'iframe',
-              url: 'https://ap.lijit.com/beacon?' + params.map(p => p.join('=')).join('&')
+              url: 'https://ce.lijit.com/beacon?' + params.map(p => p.join('=')).join('&')
             });
           }
         }

--- a/test/spec/modules/sovrnBidAdapter_spec.js
+++ b/test/spec/modules/sovrnBidAdapter_spec.js
@@ -931,7 +931,7 @@ describe('sovrnBidAdapter', function() {
     it('should return if iid present on server response & iframe syncs enabled', function() {
       const expectedReturnStatement = {
         type: 'iframe',
-        url: 'https://ap.lijit.com/beacon?informer=13487408',
+        url: 'https://ce.lijit.com/beacon?informer=13487408',
       }
       const returnStatement = spec.getUserSyncs(syncOptions, serverResponse)
 
@@ -945,7 +945,7 @@ describe('sovrnBidAdapter', function() {
       }
       const expectedReturnStatement = {
         type: 'iframe',
-        url: `https://ap.lijit.com/beacon?gdpr_consent=${gdprConsent.consentString}&informer=13487408`,
+        url: `https://ce.lijit.com/beacon?gdpr_consent=${gdprConsent.consentString}&informer=13487408`,
       }
 
       const returnStatement = spec.getUserSyncs(syncOptions, serverResponse, gdprConsent, '', null)
@@ -957,7 +957,7 @@ describe('sovrnBidAdapter', function() {
       const uspString = '1NYN'
       const expectedReturnStatement = {
         type: 'iframe',
-        url: `https://ap.lijit.com/beacon?us_privacy=${uspString}&informer=13487408`,
+        url: `https://ce.lijit.com/beacon?us_privacy=${uspString}&informer=13487408`,
       }
 
       const returnStatement = spec.getUserSyncs(syncOptions, serverResponse, null, uspString, null)
@@ -972,7 +972,7 @@ describe('sovrnBidAdapter', function() {
       }
       const expectedReturnStatement = {
         type: 'iframe',
-        url: `https://ap.lijit.com/beacon?gpp=${gppConsent.gppString}&gpp_sid=${gppConsent.applicableSections}&informer=13487408`,
+        url: `https://ce.lijit.com/beacon?gpp=${gppConsent.gppString}&gpp_sid=${gppConsent.applicableSections}&informer=13487408`,
       }
 
       const returnStatement = spec.getUserSyncs(syncOptions, serverResponse, null, '', gppConsent)
@@ -993,7 +993,7 @@ describe('sovrnBidAdapter', function() {
 
       const expectedReturnStatement = {
         type: 'iframe',
-        url: `https://ap.lijit.com/beacon?gdpr_consent=${gdprConsent.consentString}&us_privacy=${uspString}&gpp=${gppConsent.gppString}&gpp_sid=${gppConsent.applicableSections}&informer=13487408`,
+        url: `https://ce.lijit.com/beacon?gdpr_consent=${gdprConsent.consentString}&us_privacy=${uspString}&gpp=${gppConsent.gppString}&gpp_sid=${gppConsent.applicableSections}&informer=13487408`,
       }
 
       const returnStatement = spec.getUserSyncs(syncOptions, serverResponse, gdprConsent, uspString, gppConsent)


### PR DESCRIPTION
Our prebid.js adapter currently points to https://ap.lijit.com/beacon? for beacon calls - we need to switch this domain to ce.lijit.com instead to better isolate raptor calls.

<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
